### PR TITLE
chore: release workflow and changeset

### DIFF
--- a/.changeset/brave-dragons-dream.md
+++ b/.changeset/brave-dragons-dream.md
@@ -1,0 +1,7 @@
+---
+"baroview": patch
+"baroview-core": patch
+"baroview-cdn": patch
+---
+
+chore: release workflow and changesets setup

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,13 +2,23 @@ name: Release
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
 
 jobs:
   release:
+    name: Release
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -20,22 +30,30 @@ jobs:
         with:
           version: 9
 
-      - name: Setup Node
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "20"
           cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create Release PR or Publish
+      - name: Build packages
+        run: pnpm build:packages
+
+      - name: Configure npm auth for publish
+        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_BARODOC_TOKEN }}" >> .npmrc
+
+      - name: Create Release Pull Request or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
-          version: pnpm run version
-          publish: pnpm run release
-          title: "Version Packages"
-          commit: "chore: version packages"
+          version: pnpm changeset version
+          publish: pnpm release
+          commit: "chore: release packages"
+          title: "chore: release packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_BARODOC_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   ],
   "scripts": {
     "build": "pnpm --filter baroview-core build && pnpm --filter baroview build && pnpm --filter baroview-cdn build && cp packages/baroview-cdn/dist/baroview-cdn.js apps/html/public/baroview-cdn.js",
+    "build:packages": "pnpm --filter baroview-core build && pnpm --filter baroview build && pnpm --filter baroview-cdn build",
     "changeset": "changeset",
     "version": "changeset version",
     "release": "pnpm build && changeset publish",


### PR DESCRIPTION
Closes #1

- Add changeset for first release (baroview, baroview-core, baroview-cdn patch)
- Release workflow: NPM_BARODOC_TOKEN, permissions, build:packages
- Merge 후 Release 액션이 Version PR을 생성하는지 확인

Made with [Cursor](https://cursor.com)